### PR TITLE
#162300027 bg-fix display of error messages

### DIFF
--- a/src/__tests__/components/VerificationComponent.test.js
+++ b/src/__tests__/components/VerificationComponent.test.js
@@ -5,6 +5,7 @@ import VerificationComponent from '../../components/Auth/VerificationComponent';
 
 const props = {
   success: false,
+  loading: false,
   verification: jest.fn(),
   match: {
     params: {
@@ -25,5 +26,10 @@ describe('componentDidMount', () => {
   it('redirects on success', () => {
     wrapper.setProps({ success: true });
     expect(wrapper.find(Redirect).length).toEqual(1);
+  });
+
+  it('loads', () => {
+    wrapper.setProps({ success: false, loading: true });
+    expect(wrapper.find('div').length).toEqual(1);
   });
 });

--- a/src/assets/styles/Comments.scss
+++ b/src/assets/styles/Comments.scss
@@ -89,7 +89,7 @@
   margin-bottom: 10px;
 }
 
-.card {
+.card-comment {
   max-width: 800px;
   display: inline-block;
 }

--- a/src/components/Auth/SignUpComponent.jsx
+++ b/src/components/Auth/SignUpComponent.jsx
@@ -27,7 +27,8 @@ class SignUpComponent extends Component {
   }
 
   render() {
-    const { errors, success, loading } = this.props;
+    const { success, loading, error } = this.props;
+    const { errors } = error ? error.response.data : { errrors: '' };
     const {
       username, email, password, confirmPassword, passwordError,
     } = this.state;
@@ -100,7 +101,7 @@ class SignUpComponent extends Component {
 
 SignUpComponent.propTypes = {
   signup: PropTypes.func.isRequired,
-  errors: PropTypes.shape({}).isRequired,
+  error: PropTypes.shape({}).isRequired,
   success: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
 };

--- a/src/components/Auth/VerificationComponent.jsx
+++ b/src/components/Auth/VerificationComponent.jsx
@@ -9,10 +9,19 @@ class VerificationComponent extends Component {
   }
 
   render() {
-    const { success } = this.props;
+    const { success, loading } = this.props;
+    let message = 'Ooops! Something went wrong...';
+    if (success) {
+      message = '';
+    } else if (loading) {
+      message = 'loading...';
+    } else {
+      message = 'Ooops! Something went wrong...';
+    }
+
     return (
       <div className="verification">
-        {success ? <Redirect to="/login" /> : 'Ooops! Something went wrong...'}
+        {message === '' ? <Redirect to="/users/login" /> : message}
       </div>
     );
   }
@@ -20,6 +29,7 @@ class VerificationComponent extends Component {
 
 VerificationComponent.propTypes = {
   success: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
   verification: PropTypes.func.isRequired,
   match: PropTypes.string.isRequired,
 };

--- a/src/components/Comments/CommentBlockComponent.jsx
+++ b/src/components/Comments/CommentBlockComponent.jsx
@@ -145,7 +145,7 @@ class Comment extends Component {
       showThreadButton,
     } = this.state;
     return (
-      <div className="card" id="show-drop">
+      <div className="card card-comment" id="show-drop">
         {authUser() === null || authUser().username !== author ? ('') : (
           <div
             className="right waves-effect waves-dark"
@@ -159,7 +159,7 @@ class Comment extends Component {
           </div>
         ) }
 
-        <span className={this.getClassName('drop card waves-effect waves-light', showDrop)}>
+        <span className={this.getClassName('drop card card-comment waves-effect waves-light', showDrop)}>
           <input type="submit" id="edit" value="Edit" onClick={this.showEditText} className="waves-effect" />
           <input type="submit" id="show-history" value="History" onClick={this.showHistory} className="waves-effect white" />
           <input type="submit" id="on-delete" value="Delete" onClick={this.onDelete} className="waves-effect white" />
@@ -211,7 +211,7 @@ class Comment extends Component {
         </div>
         <div className={this.getClassName('card-threads z-depth-0 col s5', showThreads)}>
           {threads.map(thread => (
-            <div key={thread.id} className="card z-depth-0 thread">
+            <div key={thread.id} className="card card-comment z-depth-0 thread">
               <img
                 className="circle-thread circle thread-avatar"
                 src={thread.author.image_url === 'image-url' ? avatar : thread.author.image_url}
@@ -245,7 +245,7 @@ class Comment extends Component {
         </div>
         <div className="Reply">
           <div className={this.getClassName('input-field reply-form', showReply)}>
-            <div className=" card z-depth-0 form-reply thread">
+            <div className="card card-comment z-depth-0 form-reply thread">
               <form onSubmit={this.onReply} id="submit-reply">
                 <input
                   type="text"

--- a/src/components/Users/UpdateProfileComponent.jsx
+++ b/src/components/Users/UpdateProfileComponent.jsx
@@ -89,6 +89,7 @@ class UpdateProfileComponent extends Component {
                   defaultValue={username}
                   className="input-field"
                   minLength="4"
+                  required
                   s={12}
                 />
                 {updateProfileReducer.errors
@@ -103,6 +104,7 @@ class UpdateProfileComponent extends Component {
                   defaultValue={bio}
                   className="input-field"
                   minLength="1"
+                  required
                   s={12}
                 />
                 {updateProfileReducer.errors

--- a/src/reducers/signup.reducer.js
+++ b/src/reducers/signup.reducer.js
@@ -23,7 +23,7 @@ const signUpReducer = (state = initialState.signUp, action) => {
         ...state,
         loading: false,
         success: false,
-        errors: payload,
+        error: payload,
       };
     default:
       return state;

--- a/src/reducers/verification.reducer.js
+++ b/src/reducers/verification.reducer.js
@@ -20,6 +20,7 @@ const verifyReducer = (state = initialState.verify, action) => {
     case `${VERIFY}_REJECTED`:
       return {
         ...state,
+        loading: false,
         failed: true,
       };
     default:


### PR DESCRIPTION

## What does this PR do?
- Fixes display of error messages upon signup and profile editing

## Description of Task to be completed?
- Fix error display on signup and profile editing

- The screenshots below show show how errors will be displayed for signup and profile editing

    **Screenshots**

**Signup**
![image](https://user-images.githubusercontent.com/34505753/49219774-55f54d80-f3e5-11e8-80b2-9984d02ac765.png)

**Profile editing**
![image](https://user-images.githubusercontent.com/34505753/49220017-095e4200-f3e6-11e8-94dc-bc7a98d55fe6.png)



## Any background context you want to provide?
N/A

## What are the relevant pivotal tracker stories?
[162300027](https://www.pivotaltracker.com/n/projects/2198533/stories/162300027)

## Related PRs branch |
[bg-fix-signup-profile-errors-162300027](https://github.com/andela/ah-shakas-frontend/tree/bg-fix-signup-profile-errors-162300027)

## Todos
- [ ] Raise PR
- [ ] Test
- [ ] Documentation


